### PR TITLE
Updating the code used to generate the cleaned_page_location

### DIFF
--- a/definitions/partitioned_flattened_events.sqlx
+++ b/definitions/partitioned_flattened_events.sqlx
@@ -29,7 +29,7 @@ cte1 AS (
         CONCAT(user_pseudo_id, ( SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id, 
         (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_title') AS page_title, 
         (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location') AS page_location, 
-        SPLIT(SPLIT(REGEXP_REPLACE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)],'#')[SAFE_OFFSET(0)] AS cleaned_page_location, 
+        (COALESCE((REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'canonical_url'), 'https://www.gov.uk', '')), (SPLIT(SPLIT(REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'page_location'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)],'#')[SAFE_OFFSET(0)]))) AS cleaned_page_location, 
         (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS ga_sessionid, 
         (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number, 
         LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'primary_publishing_organisation') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 


### PR DESCRIPTION
Updating the calculation of the cleaned_page_location to default to the canonical_url if it is available, following analyst community agreement to make this change. Linked to Trello card: https://trello.com/c/V1la7AWb/216-add-update-canonical-url-dimension-fields-to-govuk-ga4-datasets