### PR TITLE
Adding regex to exclude broken page paths

### DIFF
--- a/definitions/page_summaries.sqlx
+++ b/definitions/page_summaries.sqlx
@@ -34,7 +34,8 @@ WITH
     ${ref("partitioned_flattened_events")}
   WHERE
     event_date = partition_id
-    AND NOT status_code BETWEEN 400 AND 599 ),
+    AND NOT status_code BETWEEN 400 AND 599
+    AND NOT REGEXP_CONTAINS(cleaned_page_location, "https:\\/\\/|^/www\\.\\w|\\s|\\p{Han}") ),
   
   cte2 AS (
   SELECT


### PR DESCRIPTION
Adding regex to exclude pages with paths containing 'https:', 'www.', any whitespace or any Chinese characters (broken/erroneous page paths), linked to https://trello.com/c/Cj7lxShd/223-fix-issues-with-broken-page-urls-in-pagesummaries-view