### PR TITLE
Update partitioned_flattened_events.sqlx with timestamp added as an a…

### DIFF
--- a/definitions/partitioned_flattened_events.sqlx
+++ b/definitions/partitioned_flattened_events.sqlx
@@ -19,289 +19,287 @@ pre_operations {
 }
 
  
-WITH 
-cte1 AS ( 
-    SELECT 
-        event_date AS event_date, 
-        user_pseudo_id, 
-        event_name, 
-        event_timestamp, 
-        CONCAT(user_pseudo_id, ( SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_title') AS page_title, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location') AS page_location, 
-        (COALESCE((REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'canonical_url'), 'https://www.gov.uk', '')), (SPLIT(SPLIT(REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'page_location'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)],'#')[SAFE_OFFSET(0)]))) AS cleaned_page_location, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS ga_sessionid, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'primary_publishing_organisation') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS primary_publishing_organisation, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_referrer') AS page_referrer, 
-        SPLIT(REGEXP_REPLACE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_referrer'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)] AS cleaned_page_referrer, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS content_id, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'browse_topic') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS browse_topic, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'publishing_app') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS publishing_app,
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'public_updated_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS public_updated_at, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'updated_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS updated_at, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'first_published_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS first_published_at, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_all_ids, 
-        LAST_VALUE(( SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'status_code') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS status_code, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'withdrawn') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS withdrawn, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'document_type') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS document_type, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'history') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS history, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_main_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_main_id, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_all, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_main') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_main, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_level1') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_level_1,
+WITH
+cte1 AS (
+   SELECT
+       event_date AS event_date,
+       user_pseudo_id,
+       event_name,
+       event_timestamp,
+       CONCAT(user_pseudo_id, ( SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_title') AS page_title,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location') AS page_location,
+       (COALESCE((REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'canonical_url'), 'https://www.gov.uk', '')), (SPLIT(SPLIT(REGEXP_REPLACE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'page_location'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)],'#')[SAFE_OFFSET(0)]))) AS cleaned_page_location,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') AS ga_sessionid,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'primary_publishing_organisation') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS primary_publishing_organisation,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_referrer') AS page_referrer,
+       SPLIT(REGEXP_REPLACE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_referrer'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)] AS cleaned_page_referrer,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS content_id,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'browse_topic') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS browse_topic,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'publishing_app') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS publishing_app,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'public_updated_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'),
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS public_updated_at,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'updated_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS updated_at,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'first_published_at') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS first_published_at,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_all_ids,
+       LAST_VALUE(( SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'status_code') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS status_code,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'withdrawn') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS withdrawn,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'document_type') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS document_type,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'history') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS history,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_main_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_main_id,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_all,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_main') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_main,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_level1') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS taxonomy_level_1,
 
-        LAST_VALUE(
-            (CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') ELSE '' END ) )) = '' THEN NULL ELSE 
-            (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') ELSE '' END ) )) 
-            END) IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) 
-            AS full_taxonomy_DEPRECATED, 
+       LAST_VALUE(
+           (CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') ELSE '' END ) )) = '' THEN NULL ELSE
+           (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_5') ELSE '' END ) ))
+           END) IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+           AS full_taxonomy_DEPRECATED,
 
-        LAST_VALUE(
-            (CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') ELSE '' END ), 
-            (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') ELSE '' END ) )) = '' THEN NULL ELSE 
-            (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') ELSE '' END ) )) 
-            END) IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) 
-            AS full_taxonomy_ids_DEPRECATED, 
+       LAST_VALUE(
+           (CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') ELSE '' END ),
+           (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') ELSE '' END ) )) = '' THEN NULL ELSE
+           (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'taxonomy_all_ids_5') ELSE '' END ) ))
+           END) IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+           AS full_taxonomy_ids_DEPRECATED,
 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'rendering_app') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS rendering_app, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'organisations') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS organisations, 
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'rendering_app') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS rendering_app,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'organisations') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS organisations,
 
-        IFNULL((CAST((SELECT value.int_value FROM UNNEST(event_params) WHERE key = "session_engaged") AS STRING)),(SELECT value.string_value FROM UNNEST(event_params) WHERE key = "session_engaged")) AS session_engaged,
-        LAST_VALUE(
-            (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'schema_name') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 
-            (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) 
-            AS schema_name, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'method') AS method, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'engagement_time_msec') AS engagement_time_msec, 
-        --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(not set)") AS event_campaign, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign') AS event_campaign,
+       IFNULL((CAST((SELECT value.int_value FROM UNNEST(event_params) WHERE key = "session_engaged") AS STRING)),(SELECT value.string_value FROM UNNEST(event_params) WHERE key = "session_engaged")) AS session_engaged,
+       LAST_VALUE(
+           (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'schema_name') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id,
+           (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+           AS schema_name,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'method') AS method,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'engagement_time_msec') AS engagement_time_msec,
+       --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(not set)") AS event_campaign,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign') AS event_campaign,
+           (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content_language') AS content_language,
+  
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'type') AS type,
+       --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), "direct") AS event_source,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source') AS event_source,
 
-        LAST_VALUE(
-            (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content_language') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, 
-            (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) 
-            AS content_language, 
-    
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'type') AS type, 
-        --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), "direct") AS event_source,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source') AS event_source,
+       IFNULL(FIRST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source')) OVER (PARTITION BY user_pseudo_id, ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"direct") AS session_source,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'link_text'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'link_text') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'link_text') AS STRING))) AS link_text,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'term') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS term,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_url') AS link_url,
+       --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(none)") AS event_medium,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium') AS event_medium,
 
-        IFNULL(FIRST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'source')) OVER (PARTITION BY user_pseudo_id, ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"direct") AS session_source, 
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'link_text'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'link_text') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'link_text') AS STRING))) AS link_text,
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'term') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS term, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_url') AS link_url,
-        --IFNULL(LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(none)") AS event_medium, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium') AS event_medium,
+       IFNULL(FIRST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(none)") AS session_medium,
 
-        IFNULL(FIRST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'medium')) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),"(none)") AS session_medium, 
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') AS link_domain,
+       event_previous_timestamp,
+       event_bundle_sequence_id,
+       event_server_timestamp_offset,
+       user_id,
+       user_first_touch_timestamp,
+       device.category,
+       device.mobile_brand_name,
+       device.mobile_model_name,
+       device.mobile_marketing_name,
+       device.mobile_os_hardware_model,
+       device.operating_system,
+       device.operating_system_version,
+       device.language,
+       device.is_limited_ad_tracking,
+       device.time_zone_offset_seconds,
+       device.browser AS device_browser,
+       device.browser_version AS device_browser_version,
+       device.web_info.browser,
+       device.web_info.browser_version,
+       device.web_info.hostname,
+       geo.continent,
+       geo.country,
+       geo.region,
+       geo.city,
+       geo.sub_continent,
+       geo.metro,
+       traffic_source.name AS first_user_campaign,
+       traffic_source.medium AS first_user_medium,
+       traffic_source.source AS first_user_source,
+       stream_id, platform,
+       event_dimensions.hostname AS event_dimensions_hostname,
+       CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') ELSE '' END ) )) = '' THEN NULL ELSE (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') ELSE '' END ) )) END AS full_link_URL,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'search_sort') AS search_sort,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'search_term'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'search_term') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'search_term') AS STRING))) AS search_term,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'search_results') AS search_results ,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'ui_text'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'ui_text') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'ui_text') AS STRING))) AS ui_text,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'section') AS section,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'action') AS action,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index') AS index,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_total') AS index_total,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'political_status') AS political_status,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'publishing_government') AS publishing_government,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'world_locations') AS world_locations ,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'dclid') AS dclid,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'debug_mode') AS debug_mode,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'engaged_session_event') AS engaged_session_event,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'entrances') AS entrances,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'firebase_conversion') AS firebase_conversion,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'gclid') AS gclid,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'gclsrc') AS gclsrc,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ignore_referrer') AS ignore_referrer,
 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') AS link_domain, 
-        event_previous_timestamp, 
-        event_bundle_sequence_id, 
-        event_server_timestamp_offset, 
-        user_id, 
-        user_first_touch_timestamp, 
-        device.category, 
-        device.mobile_brand_name, 
-        device.mobile_model_name, 
-        device.mobile_marketing_name, 
-        device.mobile_os_hardware_model, 
-        device.operating_system, 
-        device.operating_system_version, 
-        device.language, 
-        device.is_limited_ad_tracking, 
-        device.time_zone_offset_seconds, 
-        device.browser AS device_browser, 
-        device.browser_version AS device_browser_version, 
-        device.web_info.browser, 
-        device.web_info.browser_version,
-        device.web_info.hostname, 
-        geo.continent, 
-        geo.country, 
-        geo.region, 
-        geo.city, 
-        geo.sub_continent, 
-        geo.metro, 
-        traffic_source.name AS first_user_campaign,
-        traffic_source.medium AS first_user_medium, 
-        traffic_source.source AS first_user_source, 
-        stream_id, platform, 
-        event_dimensions.hostname AS event_dimensions_hostname, 
-        CASE WHEN (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') ELSE '' END ) )) = '' THEN NULL ELSE (CONCAT ( (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_domain') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_1') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_2') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_3') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_4') ELSE '' END ), (CASE WHEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') != "" THEN ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_path_parts_5') ELSE '' END ) )) END AS full_link_URL, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'search_sort') AS search_sort, 
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'search_term'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'search_term') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'search_term') AS STRING))) AS search_term, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'search_results') AS search_results ,
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'ui_text'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'ui_text') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'ui_text') AS STRING))) AS ui_text, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'section') AS section, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'action') AS action, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index') AS index, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_total') AS index_total, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'political_status') AS political_status, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'publishing_government') AS publishing_government, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'world_locations') AS world_locations ,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'dclid') AS dclid,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'debug_mode') AS debug_mode,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'engaged_session_event') AS engaged_session_event,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'entrances') AS entrances,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'firebase_conversion') AS firebase_conversion,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'gclid') AS gclid,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'gclsrc') AS gclsrc,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ignore_referrer') AS ignore_referrer, 
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS content,
+       LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS campaign_id,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_section') AS index_section ,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_section_total') AS index_section_total,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'tool_name') AS tool_name,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'response'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'response') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'response') AS STRING))) AS response,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ab_test') AS ab_test,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'navigation_list_type') AS navigation_list_type,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'navigation_page_type') AS navigation_page_type,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'percent_scrolled') AS percent_scrolled,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_activity_id') AS sfmc_activity_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_activity_name') AS sfmc_activity_name,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_asset_id') AS sfmc_asset_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_channel') AS sfmc_channel,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_journey_id') AS sfmc_journey_id,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_journey_name') AS sfmc_journey_name,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'step_navs') AS step_navs,
+       collected_traffic_source.manual_campaign_id,
+       collected_traffic_source.manual_campaign_name,
+       collected_traffic_source.manual_source,
+       collected_traffic_source.manual_medium,
+       collected_traffic_source.manual_term,
+       collected_traffic_source.manual_content,
+       is_active_user,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'video_title') AS video_title,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'video_url') AS video_url,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_duration') AS video_duration,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_current_time') AS video_current_time,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_percent') AS video_percent,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'cookie_banner') AS cookie_banner,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'devolved_nations_banner') AS devolved_nations_banner,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'intervention') AS intervention,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'phase_banner') AS phase_banner,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'outbound') AS outbound,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'query_string'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'query_string') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'query_string') AS STRING))) AS query_string,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'spelling_suggestion') AS spelling_suggestion,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'outcome') AS outcome,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'viewport_size') AS viewport_size,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_page_id') AS batch_page_id,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_ordering_id') AS batch_ordering_id,
+       batch_event_index,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') AS timestamp,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'copy_length') AS copy_length,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'govuk_gem_version') AS govuk_gem_version,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'global_bar') AS global_bar,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'emergency_banner') AS emergency_banner,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_tool_name') AS page_tool_name,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'autocomplete_count') AS autocomplete_count,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'autocomplete_suggestions'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_suggestions') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_suggestions') AS STRING))) AS autocomplete_suggestions,
+       (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'autocomplete_input'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_input') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_input') AS STRING))) AS autocomplete_input,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'canonical_url') AS canonical_url,
+       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'traffic_type') AS traffic_type
+  
 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'content') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS content, 
-        LAST_VALUE(( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'campaign_id') IGNORE NULLS) OVER (PARTITION BY user_pseudo_id, (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_location'), ( SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ga_session_id') ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS campaign_id,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_section') AS index_section ,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'index_section_total') AS index_section_total,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'tool_name') AS tool_name,
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'response'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'response') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'response') AS STRING))) AS response, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'ab_test') AS ab_test,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'navigation_list_type') AS navigation_list_type,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'navigation_page_type') AS navigation_page_type,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'percent_scrolled') AS percent_scrolled,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_activity_id') AS sfmc_activity_id,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_activity_name') AS sfmc_activity_name,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_asset_id') AS sfmc_asset_id,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_channel') AS sfmc_channel,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_journey_id') AS sfmc_journey_id,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'sfmc_journey_name') AS sfmc_journey_name,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'step_navs') AS step_navs,
-        collected_traffic_source.manual_campaign_id,
-        collected_traffic_source.manual_campaign_name,
-        collected_traffic_source.manual_source,
-        collected_traffic_source.manual_medium,
-        collected_traffic_source.manual_term,
-        collected_traffic_source.manual_content,
-        is_active_user,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'video_title') AS video_title,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'video_url') AS video_url,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_duration') AS video_duration,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_current_time') AS video_current_time,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'video_percent') AS video_percent,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'cookie_banner') AS cookie_banner,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'devolved_nations_banner') AS devolved_nations_banner,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'intervention') AS intervention,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'phase_banner') AS phase_banner,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'outbound') AS outbound,
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'query_string'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'query_string') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'query_string') AS STRING))) AS query_string, 
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'spelling_suggestion') AS spelling_suggestion,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'outcome') AS outcome,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'viewport_size') AS viewport_size,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_page_id') AS batch_page_id,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_ordering_id') AS batch_ordering_id,
-        batch_event_index,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') AS timestamp,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'copy_length') AS copy_length,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'govuk_gem_version') AS govuk_gem_version,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'global_bar') AS global_bar,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'emergency_banner') AS emergency_banner,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'page_tool_name') AS page_tool_name,
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'autocomplete_count') AS autocomplete_count,
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'autocomplete_suggestions'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_suggestions') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_suggestions') AS STRING))) AS autocomplete_suggestions,
-        (SELECT COALESCE((SELECT value.string_value FROM UNNEST(event_params) WHERE KEY = 'autocomplete_input'),CAST((SELECT value.int_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_input') AS STRING), CAST((SELECT value.double_value FROM UNNEST(event_params)WHERE KEY = 'autocomplete_input') AS STRING))) AS autocomplete_input,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'canonical_url') AS canonical_url,
-        (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'traffic_type') AS traffic_type
-    
-    FROM ${ref("partitioned_events")}
-    WHERE event_date = partition_id 
-    -- ${when(incremental(), 
-    --     `WHERE event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
-    --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
-    -- ) } 
+  
+   FROM ${ref("partitioned_events")}
+   WHERE event_date = partition_id
+   -- ${when(incremental(),
+   --     `WHERE event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
+   --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
+   -- ) }
 ),
+  
+cte2 AS (
+   SELECT
+     event_date AS event_date,
+     user_pseudo_id,
+     event_name,
+     event_timestamp,
+     CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id,
+     (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number,
+     items.item_list_name
     
-cte2 AS ( 
-    SELECT 
-      event_date AS event_date, 
-      user_pseudo_id, 
-      event_name, 
-      event_timestamp, 
-      CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id, 
-      (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number, 
-      items.item_list_name 
-      
-    FROM ${ref("partitioned_events")}, UNNEST(items) AS items 
-    WHERE event_date = partition_id
+   FROM ${ref("partitioned_events")}, UNNEST(items) AS items
+   WHERE event_date = partition_id
 
-    -- ${when(incremental(), 
-    --     `WHERE event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
-    --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
-    -- ) } 
+   -- ${when(incremental(),
+   --     `WHERE event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
+   --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
+   -- ) }
 ),
 
 cte3 AS (
-    SELECT 
-        event_date AS event_date, 
-        user_pseudo_id, 
-        event_name, 
-        event_timestamp, 
-        CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id, 
-        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number, 
-        items.item_id, 
-        item_name, 
-        items.item_list_index,
-        (SELECT value.string_value FROM UNNEST(item_params) WHERE key='item_content_id') AS item_content_id
-        
-    FROM ${ref("partitioned_events")}, UNNEST(items) AS items 
-    WHERE event_name = 'select_item'
-    AND event_date = partition_id
+   SELECT
+       event_date AS event_date,
+       user_pseudo_id,
+       event_name,
+       event_timestamp,
+       CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id,
+       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number,
+       items.item_id,
+       item_name,
+       items.item_list_index,
+       (SELECT value.string_value FROM UNNEST(item_params) WHERE key='item_content_id') AS item_content_id
+      
+   FROM ${ref("partitioned_events")}, UNNEST(items) AS items
+   WHERE event_name = 'select_item'
+   AND event_date = partition_id
 
-    -- ${when(incremental(), 
-    --     `AND event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
-    --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
-    -- ) } 
+   -- ${when(incremental(),
+   --     `AND event_date = TIMESTAMP(date_sub(CURRENT_DATE(), INTERVAL 1 DAY) )
+   --     AND event_date NOT IN (SELECT event_date FROM ${self()} WHERE event_date < CURRENT_TIMESTAMP())`
+   -- ) }
 
-), 
-        
+),
+      
 cte4 AS (
-    SELECT 
-        a.*, 
-        b.item_id, 
-        b.item_name, 
-        b.item_list_index ,
-        b.item_content_id
-        
-    FROM cte2 A 
-    LEFT JOIN cte3 B 
-        ON a.event_date=b.event_date 
-        AND a.user_pseudo_id=b.user_pseudo_id 
-        AND a.event_name=b.event_name 
-        AND a.event_timestamp=b.event_timestamp 
-        AND a.unique_session_id=b.unique_session_id 
-        AND a.ga_session_number=b.ga_session_number 
-    GROUP BY a.event_date, A.user_pseudo_id, A.event_name, a.event_timestamp, a.unique_session_id, a.ga_session_number, a.item_list_name, b.item_id, b.item_name, b.item_list_index, b.item_content_id 
-), 
+   SELECT
+       a.*,
+       b.item_id,
+       b.item_name,
+       b.item_list_index ,
+       b.item_content_id
+      
+   FROM cte2 A
+   LEFT JOIN cte3 B
+       ON a.event_date=b.event_date
+       AND a.user_pseudo_id=b.user_pseudo_id
+       AND a.event_name=b.event_name
+       AND a.event_timestamp=b.event_timestamp
+       AND a.unique_session_id=b.unique_session_id
+       AND a.ga_session_number=b.ga_session_number
+   GROUP BY a.event_date, A.user_pseudo_id, A.event_name, a.event_timestamp, a.unique_session_id, a.ga_session_number, a.item_list_name, b.item_id, b.item_name, b.item_list_index, b.item_content_id
+),
 
 final_cte AS (
-    SELECT 
-        a.*, 
-        b.item_list_name, 
-        b.item_id, 
-        b.item_name, 
-        b.item_list_index ,
-        b.item_content_id
-            
-    FROM cte1 a 
-    LEFT JOIN cte4 b 
-        ON a.event_date=b.event_date 
-        AND a.user_pseudo_id=b.user_pseudo_id 
-        AND a.event_name=b.event_name 
-        AND a.event_timestamp=b.event_timestamp 
-        AND a.unique_session_id=b.unique_session_id 
-        AND a.ga_session_number=b.ga_session_number) 
+   SELECT
+       a.*,
+       b.item_list_name,
+       b.item_id,
+       b.item_name,
+       b.item_list_index ,
+       b.item_content_id
+          
+   FROM cte1 a
+   LEFT JOIN cte4 b
+       ON a.event_date=b.event_date
+       AND a.user_pseudo_id=b.user_pseudo_id
+       AND a.event_name=b.event_name
+       AND a.event_timestamp=b.event_timestamp
+       AND a.unique_session_id=b.unique_session_id
+       AND a.ga_session_number=b.ga_session_number)
 
 SELECT DISTINCT * FROM final_cte


### PR DESCRIPTION
…dditional sort field, and amended content_language unnesting

Have added in 'timestamp' to window functions as tiebreaker to distinguish when we have non distinct event_timestamps, for any relevant fields. Have tested output vs original code and seems to be correct.

Have also changed content_language from a window function to just a 'normal' unnesting to better reflect the raw data for where we can have multiple languages per page. The other reason is that the devs are now aware of this, and if they are able to 'resolve' the issue of multiple languages, this unnesting will reflect any amends they make.