### PR TITLE
test content data in GA4 pipeline

### DIFF
--- a/definitions/ga4_content_data.sqlx
+++ b/definitions/ga4_content_data.sqlx
@@ -1,0 +1,151 @@
+config {
+    type: "incremental",
+    uniqueKey: ["the_date", "cleaned_page_location"],
+    database: "gds-bq-reporting",
+    schema: "processing",
+    dependencies: ["partitioned_events", "ga4_process_partition"],
+    bigquery: {
+      clusterBy: ["the_date"]
+    }
+}
+
+pre_operations {
+  DECLARE partition_id DATE;
+  SET partition_id = (
+    SELECT COALESCE(PARSE_DATE("%Y%m%d", MAX(partition_id)), DATE('1900-01-01'))
+    FROM ${ref("ga4_process_partition")}
+    );
+}
+
+WITH
+  SRC AS (
+    SELECT *
+    FROM ${ref("partitioned_events")}
+    WHERE event_date = partition_id
+  ),
+  CTE1 AS (
+  SELECT
+    user_pseudo_id,
+    (
+    SELECT
+      value.string_value
+    FROM
+      UNNEST(event_params)
+    WHERE
+      KEY = 'search_term') AS search_term,
+    SPLIT(SPLIT(REGEXP_REPLACE((
+          SELECT
+            value.string_value
+          FROM
+            UNNEST(event_params)
+          WHERE
+            KEY = 'page_location'), 'https://www.gov.uk', ''),'?')[SAFE_OFFSET(0)],'#')[SAFE_OFFSET(0)] AS cleaned_page_location,
+    (
+    SELECT
+      value.string_value
+    FROM
+      UNNEST(event_params)
+    WHERE
+      KEY = 'ui_text') AS ui_text,
+    CONCAT(user_pseudo_id, (
+      SELECT
+        value.int_value
+      FROM
+        UNNEST(event_params)
+      WHERE
+        KEY = 'ga_session_id')) AS unique_session_id,
+    (
+    SELECT
+      value.int_value
+    FROM
+      UNNEST(event_params)
+    WHERE
+      KEY = 'entrances') AS entrances,
+    event_name,
+    event_timestamp,
+    FORMAT_DATE('%Y-%m-%d', event_date) AS the_date,
+    IFNULL((CAST((
+          SELECT
+            value.int_value
+          FROM
+            UNNEST(event_params)
+          WHERE
+            KEY = "session_engaged") AS STRING)),(
+      SELECT
+        value.string_value
+      FROM
+        UNNEST(event_params)
+      WHERE
+        KEY = "session_engaged")) AS session_engaged,
+  IF
+    (LEAD(event_name) OVER (PARTITION BY CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params)
+          WHERE
+            KEY = 'ga_session_id'))
+      ORDER BY
+        event_timestamp) IS NULL, 1, NULL) AS isExit,
+  FROM
+    SRC),
+  CTE2 AS (
+  SELECT
+    the_date,
+    cleaned_page_location,
+    COUNT(DISTINCT
+      CASE
+        WHEN event_name = 'page_view' THEN unique_session_ID
+    END
+      ) AS unique_page_views,
+    COUNT(CASE
+        WHEN event_name = 'page_view' THEN unique_session_ID
+    END
+      ) AS total_page_views,
+    COUNT(DISTINCT
+      CASE
+        WHEN isexit = 1 THEN unique_session_ID
+    END
+      ) AS exits,
+    COUNT(DISTINCT
+      CASE
+        WHEN entrances = 1 THEN unique_session_ID
+    END
+      ) AS entrances,
+    COUNT(CASE
+        WHEN event_name = 'search' THEN search_term
+    END
+      ) AS total_searches,
+    COUNT(DISTINCT
+      CASE
+        WHEN event_name = 'search' THEN unique_session_id
+    END
+      ) AS unique_search_sessions,
+    COUNT(DISTINCT
+      CASE
+        WHEN event_name = 'search' THEN search_term
+    END
+      ) AS unique_searchterms,
+    COUNT(CASE
+        WHEN event_name = 'form_submit' AND ui_text = 'Yes' THEN unique_session_id
+    END
+      ) AS useful_yes,
+    COUNT(CASE
+        WHEN event_name = 'form_submit' AND ui_text = 'No' THEN unique_session_id
+    END
+      ) AS useful_no,
+    COUNT(DISTINCT
+      CASE
+        WHEN event_name = 'session_start' THEN unique_session_iD
+    END
+      ) AS session_starts,
+    COUNT(DISTINCT
+      CASE
+        WHEN session_engaged = '1' THEN unique_session_id
+    END
+      ) AS session_engaged
+  FROM
+    CTE1
+  GROUP BY
+    cleaned_page_location,
+    the_date )
+SELECT
+  *
+FROM
+  CTE2

--- a/definitions/ga4_process_partition.sqlx
+++ b/definitions/ga4_process_partition.sqlx
@@ -8,12 +8,12 @@ config {
 
 SELECT partition_id
 FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
-WHERE partition_id NOT IN (
+WHERE table_name = "partitioned_events"
+AND NOT partition_id = "__NULL__"
+AND partition_id NOT IN (
   SELECT partition_id 
   FROM `ga4-analytics-352613.flattened_dataset.INFORMATION_SCHEMA.PARTITIONS`
   WHERE table_name = 'partitioned_flattened_events'
   )
-AND table_name = "partitioned_events"
-AND NOT partition_id = "__NULL__"
 ORDER BY 1 DESC
 LIMIT 1

--- a/definitions/ga4_process_shard.sqlx
+++ b/definitions/ga4_process_shard.sqlx
@@ -7,13 +7,13 @@ config {
 
 SELECT REPLACE(table_name,'events_','') AS table_name
 FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.TABLES`
-WHERE REPLACE(table_name,'events_','') NOT IN (
+WHERE table_name NOT LIKE "%intraday%"
+AND table_name NOT LIKE "%fresh%"
+AND table_name NOT LIKE "%partitioned%"
+AND REPLACE(table_name,'events_','') NOT IN (
   SELECT partition_id 
   FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
   WHERE table_name = 'partitioned_events'
   )
-AND table_name NOT LIKE "%intraday%"
-AND table_name NOT LIKE "%fresh%"
-AND table_name NOT LIKE "%partitioned%"
 ORDER BY 1 DESC
 LIMIT 1

--- a/definitions/page_summary_partition.sqlx
+++ b/definitions/page_summary_partition.sqlx
@@ -8,12 +8,12 @@ config {
 
 SELECT partition_id
 FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
-WHERE partition_id NOT IN (
+WHERE table_name = "partitioned_events"
+AND NOT partition_id = "__NULL__"
+AND partition_id NOT IN (
   SELECT partition_id 
   FROM `ga4-analytics-352613.flattened_dataset.INFORMATION_SCHEMA.PARTITIONS`
   WHERE table_name = 'page_summaries'
   )
-AND table_name = "partitioned_events"
-AND NOT partition_id = "__NULL__"
 ORDER BY 1 DESC
 LIMIT 1

--- a/definitions/partitioned_flattened_events.sqlx
+++ b/definitions/partitioned_flattened_events.sqlx
@@ -3,7 +3,7 @@ config {
     database: "ga4-analytics-352613",
     schema: "flattened_dataset",
     bigquery: {
-        partitionBy: "DATE(event_date)",
+        partitionBy: "event_date",
         requirePartitionFilter : true,
         clusterBy: ["event_name"]
     }  

--- a/workflow_settings.yaml
+++ b/workflow_settings.yaml
@@ -2,4 +2,4 @@ defaultProject: ga4-analytics-352613
 defaultLocation: europe-west2
 defaultDataset: analytics_330577055
 defaultAssertionDataset: dataform_assertions
-dataformCoreVersion: 3.0.0-beta.4
+dataformCoreVersion: 3.0.24


### PR DESCRIPTION
- Bump version of Dataform Core to recent stable release
- Add content data for testing
- move some filtering conditions in partition tables to allow for easier commenting out when testing
- correct partition column on partitioned_flattened_events

[Successful execution](https://console.cloud.google.com/bigquery/dataform/locations/europe-west2/repositories/ga4_production_partitioning/workspaces/IA-247-2/workflows/1750755183-5e38f6ce-7afd-4db3-b938-d6050f055152?hl=en&inv=1&invt=Ab08-g&project=gds-bq-reporting) using just one day of data (2025-06-22).

[Table output](https://console.cloud.google.com/bigquery?hl=en&inv=1&invt=Ab0igw&project=gds-bq-reporting&ws=!1m35!1m4!4m3!1sgds-bq-reporting!2sprocessing!3sga4_process_shard!1m4!4m3!1sgds-bq-reporting!2sprocessing_IA_247_2!3sIA_247_2_ga4_content_data!1m4!4m3!1sga4-analytics-352613!2sanalytics_330577055!3spartitioned_events!1m4!4m3!1sgds-bq-reporting!2sprocessing_IA_247_2!3sIA_247_2_ga4_process_shard!1m4!1m3!1sgds-bq-reporting!2sbquxjob_2360cc16_197a10b4778!3seurope-west2!1m4!1m3!1sgds-bq-reporting!2sbquxjob_7be7800c_197a1165bdd!3seurope-west2!1m4!4m3!1sgds-bq-reporting!2sprocessing!3sga4_process_partition) - `gds-bq-reporting.processing_IA_247_2.IA_247_2_ga4_content_data`.