### PR TITLE
Remove the latest changes to add extra join keys for select_item fields

### DIFF
--- a/definitions/partitioned_flattened_events.sqlx
+++ b/definitions/partitioned_flattened_events.sqlx
@@ -230,9 +230,6 @@ cte2 AS (
      event_timestamp,
      CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id,
      (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number,
-     (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') AS timestamp,
-     (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_event_index') AS batch_event_index,
-     (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_url') AS link_url,
      items.item_list_name
      
     
@@ -253,9 +250,6 @@ cte3 AS (
        event_timestamp,
        CONCAT(user_pseudo_id, (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_id')) AS unique_session_id,
        (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'ga_session_number') AS ga_session_number,
-       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'timestamp') AS timestamp,
-       (SELECT value.int_value FROM UNNEST(event_params) WHERE key = 'batch_event_index') AS batch_event_index,
-       (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'link_url') AS link_url,
        items.item_id,
        item_name,
        items.item_list_index,
@@ -288,10 +282,7 @@ cte4 AS (
        AND a.event_timestamp=b.event_timestamp
        AND a.unique_session_id=b.unique_session_id
        AND a.ga_session_number=b.ga_session_number
-       AND COALESCE(a.timestamp, 0)=COALESCE(b.timestamp, 0)
-       AND COALESCE(a.batch_event_index, 0)=COALESCE(b.batch_event_index, 0)
-       AND COALESCE(a.link_url, " ") = COALESCE(b.link_url,  " ")
-   GROUP BY a.event_date, A.user_pseudo_id, A.event_name, a.event_timestamp, a.unique_session_id, a.ga_session_number, a.timestamp, a.batch_event_index, a.link_url, a.item_list_name, b.item_id, b.item_name, b.item_list_index, b.item_content_id
+   GROUP BY a.event_date, A.user_pseudo_id, A.event_name, a.event_timestamp, a.unique_session_id, a.ga_session_number, a.item_list_name, b.item_id, b.item_name, b.item_list_index, b.item_content_id
 ),
 
 final_cte AS (
@@ -311,9 +302,6 @@ final_cte AS (
        AND a.event_timestamp=b.event_timestamp
        AND a.unique_session_id=b.unique_session_id
        AND a.ga_session_number=b.ga_session_number
-       AND COALESCE(a.timestamp, 0)=COALESCE(b.timestamp, 0)
-       AND COALESCE(a.batch_event_index, 0)=COALESCE(b.batch_event_index, 0)
-       AND COALESCE(a.link_url, " ") = COALESCE(b.link_url,  " ")
 )
 
 SELECT DISTINCT * FROM final_cte


### PR DESCRIPTION
The extra join keys were to stop duplication in the select_item flattened data but they have resulted in a loss of data in the e-commerce fields in the last few days. This change is to put things back to how they were.