### PR TITLE
make source tables dynamic

### DIFF
--- a/definitions/ga4_process_partition.sqlx
+++ b/definitions/ga4_process_partition.sqlx
@@ -7,7 +7,7 @@ config {
 
 
 SELECT partition_id
-FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
+FROM `ga4-analytics-352613.analytics_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.PARTITIONS`
 WHERE table_name = "partitioned_events"
 AND NOT partition_id = "__NULL__"
 AND partition_id NOT IN (
@@ -17,3 +17,5 @@ AND partition_id NOT IN (
   )
 ORDER BY 1 DESC
 LIMIT 1
+
+

--- a/definitions/ga4_process_shard.sqlx
+++ b/definitions/ga4_process_shard.sqlx
@@ -6,14 +6,15 @@ config {
 
 
 SELECT REPLACE(table_name,'events_','') AS table_name
-FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.TABLES`
+FROM `ga4-analytics-352613.analytics_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.TABLES`
 WHERE table_name NOT LIKE "%intraday%"
 AND table_name NOT LIKE "%fresh%"
 AND table_name NOT LIKE "%partitioned%"
 AND REPLACE(table_name,'events_','') NOT IN (
   SELECT partition_id 
-  FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
+  FROM `ga4-analytics-352613.analytics_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.PARTITIONS`
   WHERE table_name = 'partitioned_events'
   )
 ORDER BY 1 DESC
 LIMIT 1
+

--- a/definitions/page_summary_partition.sqlx
+++ b/definitions/page_summary_partition.sqlx
@@ -7,7 +7,7 @@ config {
 
 
 SELECT partition_id
-FROM `ga4-analytics-352613.analytics_330577055.INFORMATION_SCHEMA.PARTITIONS`
+FROM `ga4-analytics-352613.analytics_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.PARTITIONS`
 WHERE table_name = "partitioned_events"
 AND NOT partition_id = "__NULL__"
 AND partition_id NOT IN (


### PR DESCRIPTION
source tables to identify process shard and partition is now based on the name of the workspace