### PR TITLE
Clarify output table dependencies

### DIFF
--- a/definitions/processing/navigation_partition.sqlx
+++ b/definitions/processing/navigation_partition.sqlx
@@ -3,13 +3,13 @@ config {
   tags: [dataform.projectConfig.vars.environment],
   database: dataform.projectConfig.vars.processing_database,
   schema: dataform.projectConfig.vars.processing_schema,
-  dependencies: [ "partitioned_events"]
+  dependencies: [ "partitioned_flattened_events"]
 }
 
 
 SELECT partition_id
-FROM `${dataform.projectConfig.vars.source_database}.${dataform.projectConfig.vars.source_ga4_prod_schema}.INFORMATION_SCHEMA.PARTITIONS`
-WHERE table_name = "partitioned_events"
+FROM `${dataform.projectConfig.vars.source_database}.${dataform.projectConfig.vars.source_flattened_dataset}.INFORMATION_SCHEMA.PARTITIONS`
+WHERE table_name = "partitioned_flattened_events"
 AND NOT partition_id = "__NULL__"
 AND partition_id NOT IN (
   SELECT partition_id 

--- a/definitions/processing/page_summary_partition.sqlx
+++ b/definitions/processing/page_summary_partition.sqlx
@@ -3,13 +3,13 @@ config {
   tags: [dataform.projectConfig.vars.environment],
   database: dataform.projectConfig.vars.processing_database,
   schema: dataform.projectConfig.vars.processing_schema,
-  dependencies: [ "partitioned_events"]
+  dependencies: [ "partitioned_flattened_events"]
 }
 
 
 SELECT partition_id
-FROM `${dataform.projectConfig.vars.source_database}.${dataform.projectConfig.vars.source_ga4_prod_schema}.INFORMATION_SCHEMA.PARTITIONS`
-WHERE table_name = "partitioned_events"
+FROM `${dataform.projectConfig.vars.source_database}.${dataform.projectConfig.vars.source_flattened_dataset}.INFORMATION_SCHEMA.PARTITIONS`
+WHERE table_name = "partitioned_flattened_events"
 AND NOT partition_id = "__NULL__"
 AND partition_id NOT IN (
   SELECT partition_id 


### PR DESCRIPTION
This PR changes the dependencies of output table to be that paritioned_flattened_events table, which is where they pull their data from.

This has been check in dev and works as expected