### PR TITLE
IA-2774 - create new variable in workflow settings

### DIFF
--- a/workflow_settings.dev.yaml
+++ b/workflow_settings.dev.yaml
@@ -27,3 +27,4 @@ vars:
   # Date variables
   start_date: "20260329"
   partitioned_events_table_suffix: "20270101"
+  aggregate_consent_start_date: "20280101"

--- a/workflow_settings.prod.yaml
+++ b/workflow_settings.prod.yaml
@@ -27,3 +27,4 @@ vars:
   # Date variables
   start_date: "19000101"
   partitioned_events_table_suffix: "20250101"
+  aggregate_consent_start_date: "20280101"

--- a/workflow_settings.yaml
+++ b/workflow_settings.yaml
@@ -27,3 +27,4 @@ vars:
   # Date variables
   start_date: "19000101"
   partitioned_events_table_suffix: "20250101"
+  aggregate_consent_start_date: "20280101"


### PR DESCRIPTION
This PR creates a new variable in the workflow settings files defining the date that no consented aggregate data was made available. This is currently set to a date in the future.